### PR TITLE
Add automated releases on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+
+    - name: Build
+      run: msbuild DllWrapper.sln /p:Configuration=Release /p:Platform=x64 /p:PostBuildEventUseInBuild=false
+
+    - name: Create ZIP Archive
+      run: Compress-Archive -Path x64\Release\dxgi.dll, walkingman.ini -DestinationPath walkingman_${{ github.ref_name }}.zip
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: walkingman_${{ github.ref_name }}.zip

--- a/walkingman.ini
+++ b/walkingman.ini
@@ -1,0 +1,81 @@
+// This is a comment
+// Comments start with "//"
+// Comments are ignored within this file
+// Comments are useful,
+// for example you can effectively remove a song from the playlist by adding "//" at the start of an entry in [Playlist]
+
+// This file allows configuring Walkman, a Death Stranding music player mod
+
+
+[Global Settings]
+
+showSongDescription = 1  // Whether to show name - artist - label when the mod plays a new song. 1 to toggle on, 0 to toggle off
+showNotificationMessage = 1  // Whether to show in-game notifications for mod events (music player interruption, ...)
+connectToChiralNetwork = 1  // Whether the music player availability depends on the in-game chiral network
+
+// These two are mostly for streaming/uploading gameplay and avoiding copyright issues. Toggle both off to avoid song playback (except in cutscenes)
+
+allowScriptedSongs = 1  // Whether to allow scripted music to play when reaching certain points in the game
+showMusicPlayerUI = 1  // Whether the mod's music player UI shows in the game. Toggle off to make sure no song is played by mistake
+
+
+[Playlist]  // Playlist dictates which songs to play and in what order
+
+Don't Be So Serious
+Bones
+Poznan
+Anything You Need
+Easy Way Out
+I'm Leaving
+Give Up
+Gosia
+Without You
+Breathe In
+Because We Have To
+St. Eriksplan
+Rolling Over
+Once in a Long, Long While...
+The Machine
+Patience
+Not Around
+Please Don't Stop (Chapter 1)
+Tonight, tonight, tonight
+Please Don't Stop (Chapter 2)
+Half Asleep
+Waiting (10 Years)
+Nobody Else
+Asylums For The Feeling
+Almost Nothing
+BB's Theme
+
+// Director's Cut exclusives. It's alright to leave them active on the Standard version, they will be skipped
+
+Pale Yellow
+Goliath
+Control
+Other Me
+Fragile
+
+// Ambient music I found decent enough. Can be an alternative if you dislike music with lyrics or want to avoid the licensed songs
+
+// Ambient 1
+// Ambient 2
+// Ambient 3
+// Ambient 4
+// Ambient 5
+// Ambient 6
+// Ambient 7
+
+// The following are duplicates and alternate versions that might not be worthwile
+
+// Almost Nothing (Instrumental)  // Instrumental only version of "Almost Nothing"
+// Almost Nothing (No Beatbox)  // No-beatbox version
+// Patience (duplicate 1)  // Duplicates seem to show no difference to non-duplicate versions
+// Rolling Over (duplicate 1)
+// Bones (duplicate 1)
+// Without You (duplicate 1)
+// Bones (end 1)  // Seemingly plays only the ending part of the song
+// Bones (end 2)
+// Because We Have To (duplicate 1)
+// Bones (duplicate 2)
+// Bones (duplicate 3)


### PR DESCRIPTION
Hi @HamzaEzzRa,

Here is the CI/CD workflow as requested. It triggers automatically on tags matching `v*` (e.g., `v1.0.6`). 

It builds the solution and packages `dxgi.dll` and `walkingman.ini` into a `.zip` archive, attaching it directly to the GitHub Release. 

*(Note: I also included the `walkingman.ini` file in the root directory in this PR, as the deployment script needs it to package the final archive properly).*

Let me know if you need any adjustments to the artifact names!